### PR TITLE
Only backup database once a day instead of 60 times per day

### DIFF
--- a/crontabs/ldap
+++ b/crontabs/ldap
@@ -1,1 +1,1 @@
-* 5 * * * openldap . /env ; /entrypoint/backup
+23 5 * * * openldap . /env ; /entrypoint/backup


### PR DESCRIPTION
Instead of generating one backup every minute at 5AM UTC, we should only have one per day