### PR TITLE
chore: add `skip-changelog` label to Dependabot's GHA configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "skip-changelog"


### PR DESCRIPTION
This change adds a "skip-changelog" label to dependabot PRs concerning a GitHub Action like release-drafter, to avoid releases of new images like https://github.com/jenkins-infra/docker-ldap/releases/tag/2.1.29 when those GHAs are bumped while they're not included in the images.