### PR TITLE
Revert "chore: add `skip-changelog` label to Dependabot's GHA configuration"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    labels:
-      - "skip-changelog"


### PR DESCRIPTION
Reverts jenkins-infra/docker-ldap#77

Cf  https://github.com/jenkins-infra/docker-ldap/issues/77#issuecomment-4803688057:

> Adding the label will only hide the change from changelog but won't prevent releases.
         